### PR TITLE
エンディングの演出案を追加しました

### DIFF
--- a/data/scenario/first.ks
+++ b/data/scenario/first.ks
@@ -11,6 +11,8 @@
 
 ;ゲームで必ず必要な初期化処理はこのファイルに記述するのがオススメ
 
+@call storage="macro.ks"
+
 ;メッセージボックスは非表示
 @layopt layer="message" visible=false
 

--- a/data/scenario/macro.ks
+++ b/data/scenario/macro.ks
@@ -1,5 +1,35 @@
 ;純硫黄のとりあえず作ってみたマクロ群
 
+*start
+
 [macro name="chara_clean"]
 
 [endmacro]
+
+; エンディングの演出
+[macro name="ending_text"]
+    [cm]
+    [wait time="500"]
+
+    ;全ての表示を消す
+    [layopt layer="message0" visible=false]
+    [hidemenubutton]
+    [mask effect="fadeIn" time=2000]
+    [freeimage layer="base"]
+    [layopt layer=0 visible=true]
+    [mask_off]
+
+    ; ここは以下のいずれか（もしくは複数）が良さそう？
+    ; - 「Happy End」などをmtextで表示する
+    ; - エンディングスチルを表示する
+    ; - エンドロールを流す
+    ; - エンディング曲を流す
+
+    ; textに指定した文字列のスペースが表示されないので文字実体参照で記入します
+    [mtext text="%text" x=0 y=240 width=1280 align="center" size=120 color="0x111111" edge="0xffffff" in_effect="flipInX"]
+
+    ; 一定時間が経過したのち自動的にタイトルへ戻る
+    [wait time="1000"]
+[endmacro]
+
+[return]

--- a/data/scenario/scene2.ks
+++ b/data/scenario/scene2.ks
@@ -2,8 +2,28 @@
 
 #？
 まだできてないよ～～～～～～～～～！！！！！！！[l][r]
-ゲームを終了します。
-*endloop
-[l]
-[close ask=true]
-@jump target = endloop
+
+; エンディングの演出
+[cm]
+[wait time="500"]
+
+;全ての表示を消す
+[layopt layer="message0" visible=false]
+[hidemenubutton]
+[mask effect="fadeIn" time=2000]
+[freeimage layer="base"]
+[layopt layer=0 visible=true]
+[mask_off]
+
+; ここは以下のいずれか（もしくは複数）が良さそう？
+; - 「Happy End」などをmtextで表示する
+; - エンディングスチルを表示する
+; - エンドロールを流す
+; - エンディング曲を流す
+
+; textに指定した文字列のスペースが表示されないので文字実体参照で記入します
+[mtext text="To&nbsp;be&nbsp;continued..." x=0 y=240 width=1280 align="center" size=120 color="0x111111" edge="0xffffff" in_effect="flipInX"]
+
+; 一定時間が経過したのち自動的にタイトルへ戻る
+[wait time="1000"]
+[jump storage="title.ks"]

--- a/data/scenario/scene2.ks
+++ b/data/scenario/scene2.ks
@@ -3,27 +3,5 @@
 #？
 まだできてないよ～～～～～～～～～！！！！！！！[l][r]
 
-; エンディングの演出
-[cm]
-[wait time="500"]
-
-;全ての表示を消す
-[layopt layer="message0" visible=false]
-[hidemenubutton]
-[mask effect="fadeIn" time=2000]
-[freeimage layer="base"]
-[layopt layer=0 visible=true]
-[mask_off]
-
-; ここは以下のいずれか（もしくは複数）が良さそう？
-; - 「Happy End」などをmtextで表示する
-; - エンディングスチルを表示する
-; - エンドロールを流す
-; - エンディング曲を流す
-
-; textに指定した文字列のスペースが表示されないので文字実体参照で記入します
-[mtext text="To&nbsp;be&nbsp;continued..." x=0 y=240 width=1280 align="center" size=120 color="0x111111" edge="0xffffff" in_effect="flipInX"]
-
-; 一定時間が経過したのち自動的にタイトルへ戻る
-[wait time="1000"]
+[ending_text text="To&nbsp;be&nbsp;continued..."]
 [jump storage="title.ks"]


### PR DESCRIPTION
よくあるエンディングの演出についてヒアリングしたところ以下のような意見があったので、現状のスクリプトの最後に入れてみました。
1つの案として見てみてください。

- 最後はエンディング用のスチル・エンドロールなど表示されることがおおい
- 最後はクリックしなくてもタイトル画面に戻る

今回の修正では時間経過でしかタイトルに戻れないので、（たとえば）エンドロールが流れている途中でもクリックで終了できるようにしたほうがいいかもしれません。