### PR TITLE
メッセージウィンドウ周りを修正

### DIFF
--- a/data/others/css/message.css
+++ b/data/others/css/message.css
@@ -1,0 +1,19 @@
+/* メッセージ枠の設定*/
+/* radial-gradient の複数色で縞模様を作るときに使う 'px' や '%' の指定は使えない. */
+.message_outer{
+    background: radial-gradient(circle farthest-side, rgba(34, 33, 31,0.8),rgba(34, 33, 31,0.8),rgba(34, 33, 31,0.5),rgba(34, 33, 31,0));
+    filter: blur(2px);
+}
+/* メッセージウィンドウ内の本文の設定 */
+/* letter-spacingは設定できるが, shadow などはjsに上書きされてしまう*/
+/* おそらく tyrano/plugin/kag/ 内のjsで上書きされているものは扱えない模様 */
+.current_span{
+    letter-spacing: 0.2em;
+}
+/* 文字表示枠の設定 */
+/* .message_inner{
+} */
+
+/* 名前表示枠の文字の設定 */
+/* .chara_name_area{
+} */

--- a/data/scenario/scene1.ks
+++ b/data/scenario/scene1.ks
@@ -8,18 +8,29 @@
 [freeimage layer="base" time=100]
 
 ;メッセージウィンドウの設定
-[position layer="message0" left=160 top=500 width=1000 height=200 page="fore"]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;colorに透明色を指定して直接cssでmessage_outerクラスを指定して上書きしている.
+;colorに何も指定しないとデフォルト設定での上書きが優先されるらしくcssを読み込んでくれない. 
+;"red","white"などと書いた場合は上からbackgroundで描いたものが乗っかる感じになりうまくいかない.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+[position layer="message0" left=60 top=500 width=1200 height=200 page="fore" visible=false opacity=255 color="rgba(0,0,0,0)"]
 ;文字が表示される領域を調整
-[position layer="message0" page="fore" margint=45 marginl=50 marginr=70 marginb=60]
+[position layer="message0" page="fore" margint=35 marginl=150 marginr=150 marginb=60]
 ;メッセージボックスは初期状態では非表示
 @layopt layer="message" visible=true
-
+;フォントを設定
+[deffont size=26 color="white" face="gennei-latemin" edge="none" shadow="rgba(0,0,0,0.5)" effect="fadeIn" effect_speed="0.2s"]
+[resetfont]
 ;メニューボタンを表示
 @showmenubutton
 ;キャラクターの名前が表示される文字領域
-[ptext name="chara_name_area" layer="message0" color="white" size=28 bold=true x=180 y=510]
+[ptext name="chara_name_area" layer="message0" color="white" face="gennei-latemin" shadow="rgba(0,0,0,0.5)" size=30 bold=false x=180 y=510]
 ;上記で定義した領域がキャラクターの名前表示であることを宣言（これがないと#の部分でエラーになります）
 [chara_config ptext="chara_name_area"]
+
+
+;cssの読み込み
+[loadcss file="./data/others/css/message.css"]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;本文(背景未表示)
 充填されていた気体が溢れ出す。[l][r]

--- a/data/system/Config.tjs
+++ b/data/system/Config.tjs
@@ -323,7 +323,7 @@
 // userFace の設定を変更し、適用したい場合はシステム変数ファイル
 // カンマで区切って複数のフォントを指定することができます。その場合は、最初
 // の方に書いたフォントが存在すれば、優先されます。
-;userFace = Quicksand, 游ゴシック体, "Yu Gothic", YuGothic, "ヒラギノ角ゴシック Pro", "Hiragino Kaku Gothic Pro", メイリオ, Meiryo, Osaka, "ＭＳ Ｐゴシック", "MS PGothic", sans-serif, Arial; 
+;userFace = 源暎ラテミン, Quicksand, 游ゴシック体, "Yu Gothic", YuGothic, "ヒラギノ角ゴシック Pro", "Hiragino Kaku Gothic Pro", メイリオ, Meiryo, Osaka, "ＭＳ Ｐゴシック", "MS PGothic", sans-serif, Arial; 
 
 
 // ◆ 文字の色

--- a/tyrano/css/font.css
+++ b/tyrano/css/font.css
@@ -1,7 +1,6 @@
 /*ウェブフォントを使用する場合はここに定義を追加して下さい*/
 
 /*
-    
 @font-face {
 	font-family:"mfrules";
 	src:url("../../data/others/Mf_Break_The_Rules.eot?") format("eot"),
@@ -10,7 +9,14 @@
 	url("../../data/others/Mf_Break_The_Rules.svg#MfBreakTheRules") format("svg");
 	font-weight:normal;font-style:normal;
 }
-
 */
 
-
+/* ライセンス表示
+"源暎ラテミン" licensed under the SIL Open Font License 1.1
+https://okoneya.jp/font/genei-latin.html
+*/
+@font-face {
+	font-family:"gennei-latemin";
+	src:url("../../data/others/GenEiLateMinN_v2.ttf") format("truetype");
+	font-weight:normal;font-style:normal;
+}


### PR DESCRIPTION
- 使用フォントを源暎ラテミンに変更
- メッセージウィンドウのデザインを設定
- こまごまとした部分をいじるためにmessage.cssを作成，配置

どうやらcss側からだと一部の変更が機能しないみたいです(text-shadowとか)．  
多分 `tyrano/plugins/kag/` 内のjsに上書きされてるんだと思いますが，なんとかユーザ側だけで変更処理を押し通したくて思案中です．[is]タグや[html]タグでcssを挿入したら上書きできるのかもしれません．